### PR TITLE
New Clerk's Shop Layout on Yogsbox

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -715,26 +715,18 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "abN" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/wood,
+/obj/item/instrument/accordion,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "giftshop";
 	name = "gift shop shutters"
 	},
-/obj/machinery/camera{
-	c_tag = "Clerk's office";
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "abO" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -907,10 +899,21 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "aci" = (
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "acj" = (
 /obj/machinery/light{
@@ -940,51 +943,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"acl" = (
-/obj/structure/table,
-/obj/item/instrument/violin,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "acm" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/piano,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "acn" = (
 /obj/item/storage/secure/safe/HoS{
@@ -1150,17 +1117,13 @@
 /area/security/prison)
 "acF" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "acG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1233,24 +1196,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"acL" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "acM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5187,27 +5132,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"ajX" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "ajY" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7132,18 +7056,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"anO" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
-	},
-/turf/open/space/basic,
-/area/space)
 "anP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -12476,37 +12388,48 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "azK" = (
-/obj/structure/piano,
-/turf/open/floor/plating,
+/obj/machinery/button/door{
+	id = "giftshop";
+	name = "Gift Shop Lockdown";
+	pixel_y = 24
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "azL" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "intact";
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "intact";
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "azM" = (
 /obj/machinery/light,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "azN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "intact";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "azO" = (
 /obj/structure/cable{
@@ -13145,9 +13068,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aBe" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "aBf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -13157,11 +13081,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aBg" = (
-/obj/structure/closet/crate,
-/obj/item/target/syndicate,
-/obj/item/target,
-/obj/item/target/alien,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "aBh" = (
 /obj/machinery/camera{
@@ -13429,15 +13353,6 @@
 /obj/item/gun/energy/ionrifle,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aBY" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/clerk)
 "aBZ" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
@@ -13908,46 +13823,19 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDi" = (
-/obj/structure/table,
-/obj/item/instrument/guitar,
-/obj/machinery/button/door{
-	id = "giftshop";
-	name = "Gift Shop Button";
-	pixel_y = 24
+/obj/structure/table/wood,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "intact";
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aDj" = (
-/obj/machinery/vending/games,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/window/southleft{
+	name = "Clerk Desk";
+	req_access_txt = "36"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aDk" = (
 /obj/structure/table,
@@ -14037,17 +13925,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aDw" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "aDx" = (
 /obj/machinery/computer/upload/ai,
@@ -14057,18 +13941,15 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDy" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/item/instrument/guitar,
+/obj/structure/rack,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aDz" = (
 /obj/structure/rack,
@@ -14713,44 +14594,22 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aEQ" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/yogs/clerk,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "intact";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
-"aER" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
+"aER" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "aES" = (
 /obj/effect/turf_decal/stripes{
@@ -14763,41 +14622,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"aET" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/stack/sheet/cardboard,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
-"aEU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "aEV" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -15244,24 +15068,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aFW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "aFX" = (
 /obj/machinery/computer/upload/borg,
 /obj/machinery/airalarm{
@@ -15294,20 +15100,15 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aGf" = (
-/obj/structure/table,
-/obj/item/a_gift,
-/obj/item/a_gift,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/instrument/saxophone,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aGg" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -16061,20 +15862,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aHL" = (
-/obj/structure/table,
-/obj/item/bikehorn/rubberducky,
-/obj/item/camera,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/instrument/trombone,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aHN" = (
 /obj/structure/table,
@@ -16638,20 +16434,18 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJa" = (
+/obj/structure/table/wood,
+/obj/item/instrument/glockenspiel,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aJb" = (
 /obj/effect/turf_decal/delivery,
@@ -16683,20 +16477,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJi" = (
-/obj/structure/table,
-/obj/item/key,
-/obj/item/camera_film,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/instrument/harmonica,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "aJj" = (
 /obj/structure/table,
@@ -17826,11 +17615,9 @@
 /area/crew_quarters/kitchen)
 "aMq" = (
 /obj/structure/table/wood,
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/obj/item/instrument/eguitar{
-	pixel_x = 5
+/obj/item/paper/guides/recycler{
+	info = "Psst, you can check out more musical instruments from the Clerk's Shop!";
+	name = "paper - 'Musical Instruments'"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -18277,7 +18064,6 @@
 "aNG" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/wood,
-/obj/item/instrument/violin,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aNH" = (
@@ -34651,24 +34437,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"bCx" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "bCz" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -50966,27 +50734,6 @@
 "gfH" = (
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"ghg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "intact";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "giW" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -52495,6 +52242,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
+"jmj" = (
+/obj/machinery/paystand,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "jmH" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
@@ -52838,9 +52591,9 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "kaU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "kbp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53473,7 +53226,7 @@
 	icon_state = "vent_map_on";
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "lge" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -53714,6 +53467,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lyh" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "lzH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -54116,6 +53877,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/entrance)
+"miD" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "miX" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -55462,6 +55230,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/lounge)
+"oZD" = (
+/obj/item/instrument/eguitar,
+/obj/structure/rack,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "paA" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -55502,6 +55281,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"pcF" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "pdz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -56114,6 +55899,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qqY" = (
+/obj/machinery/door/airlock{
+	name = "Commissary";
+	req_access_txt = "36"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "qrA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57086,6 +56878,15 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"sox" = (
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "soO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59489,21 +59290,17 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wsg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "intact";
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "intact";
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/turf/open/floor/plasteel{
+	icon_state = "wood"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/clerk)
 "wsq" = (
 /obj/effect/turf_decal/tile/blue{
@@ -60314,9 +60111,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xSu" = (
+/obj/item/instrument/violin,
 /obj/structure/rack,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop";
+	name = "gift shop shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
 /area/clerk)
 "xUt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60487,6 +60290,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"yeO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "yfa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83306,7 +83120,7 @@ arP
 arP
 kVU
 rPk
-alu
+yeO
 xvj
 alu
 aHG
@@ -84590,7 +84404,7 @@ axo
 cCi
 aDz
 kVU
-kVU
+qqY
 kVU
 kVU
 kVU
@@ -85104,7 +84918,7 @@ axt
 ayG
 ayG
 ayG
-ayG
+sox
 ayG
 ayG
 ayG
@@ -85347,7 +85161,7 @@ aaa
 aaa
 aaa
 aaa
-anO
+aaa
 aaa
 aaa
 aaa
@@ -85361,13 +85175,13 @@ axt
 ayG
 azK
 aBe
-ayG
+kaU
 aDj
 aER
 abN
 acm
 aJa
-acF
+ayG
 aLN
 aLE
 aLE
@@ -85616,14 +85430,14 @@ aqR
 aqR
 axt
 ayG
-ayG
-ayG
-ayG
+miD
+jmj
+lyh
 aDi
 aEQ
-aFW
-aDw
-aDw
+kaU
+pcF
+kaU
 acF
 aLN
 aLE
@@ -85875,13 +85689,13 @@ axt
 ayG
 aci
 aBg
-ayG
-acl
+aBg
+aBg
 wsg
-aET
-bCx
-ajX
-ayG
+kaU
+kaU
+kaU
+acF
 aLN
 aLE
 aLE
@@ -86132,13 +85946,13 @@ axt
 ayG
 azL
 kaU
-aBY
-ghg
+kaU
+kaU
 aDw
-aDw
-aDw
-aDw
-acL
+kaU
+kaU
+kaU
+acF
 aLN
 aLE
 aOz
@@ -86389,9 +86203,9 @@ axt
 ayG
 azN
 xSu
-ayG
+oZD
 aDy
-aEU
+kaU
 aGf
 aHL
 aJi

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -720,10 +720,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -945,10 +941,6 @@
 /area/maintenance/fore)
 "acm" = (
 /obj/structure/piano,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -13824,6 +13816,7 @@
 /area/storage/primary)
 "aDi" = (
 /obj/structure/table/wood,
+/obj/item/stack/wrapping_paper,
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -13943,10 +13936,6 @@
 "aDy" = (
 /obj/item/instrument/guitar,
 /obj/structure/rack,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -15102,10 +15091,6 @@
 "aGf" = (
 /obj/structure/table/wood,
 /obj/item/instrument/saxophone,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -15864,10 +15849,6 @@
 "aHL" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -16439,10 +16420,6 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -16479,10 +16456,6 @@
 "aJi" = (
 /obj/structure/table/wood,
 /obj/item/instrument/harmonica,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -17400,12 +17373,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aLN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aLO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -17447,13 +17414,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aLT" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aLU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/xeno_spawn,
@@ -49784,13 +49744,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eJy" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
+/obj/machinery/door/airlock/maintenance{
 	req_access_txt = "36"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
+/turf/open/floor/plating,
 /area/clerk)
 "eKd" = (
 /obj/machinery/door/airlock/maintenance{
@@ -50113,6 +50070,17 @@
 "fip" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
+"fki" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Life Support";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "fkp" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 8;
@@ -52826,6 +52794,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"kqS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "kqT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -53730,7 +53711,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/clerk)
 "lVx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -55239,10 +55220,6 @@
 "pau" = (
 /obj/item/instrument/eguitar,
 /obj/structure/rack,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -56630,11 +56607,10 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "rQe" = (
-/obj/machinery/door/airlock{
-	name = "Commissary";
+/obj/machinery/door/airlock/maintenance{
 	req_access_txt = "36"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/vacant_room/commissary)
 "rQW" = (
 /obj/structure/window/reinforced{
@@ -57467,13 +57443,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/vacant_room/commissary";
-	dir = 4;
-	name = "Vacant Commissary APC";
-	pixel_x = 2;
-	pixel_y = -27
-	},
 /obj/structure/rack,
 /obj/item/wrench,
 /obj/item/screwdriver,
@@ -60121,10 +60090,6 @@
 "xSu" = (
 /obj/item/instrument/violin,
 /obj/structure/rack,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -60156,12 +60121,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xWs" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "xWw" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -84665,7 +84624,7 @@ ayH
 ayH
 kpg
 ayH
-ayH
+kqS
 ayH
 aFV
 ayH
@@ -85185,7 +85144,7 @@ abN
 acm
 aJa
 ayG
-xWs
+aLE
 aLE
 aLE
 aLE
@@ -85442,7 +85401,7 @@ kaU
 ovk
 kaU
 acF
-aLN
+aLE
 aLE
 aLE
 aLE
@@ -85699,7 +85658,7 @@ kaU
 kaU
 kaU
 acF
-aLN
+aLE
 aLE
 aLE
 aLE
@@ -85956,7 +85915,7 @@ kaU
 kaU
 kaU
 acF
-aLN
+aLE
 aLE
 aOz
 aLE
@@ -86208,12 +86167,12 @@ azN
 xSu
 pau
 aDy
-kaU
+fki
 aGf
 aHL
 aJi
 ayG
-aLT
+aLF
 aLF
 aLF
 qLZ

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -49792,6 +49792,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"eJy" = (
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "eKd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Detective Maintenance";
@@ -50940,6 +50949,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gCb" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "gCG" = (
 /obj/machinery/door/airlock/hatch{
 	autoclose = 0;
@@ -51990,6 +52006,14 @@
 "iMH" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"iMM" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "iNR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "intact";
@@ -52242,12 +52266,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
-"jmj" = (
-/obj/machinery/paystand,
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
-/area/clerk)
 "jmH" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
@@ -52335,6 +52353,12 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"jvL" = (
+/obj/machinery/paystand,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "jyf" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -53467,14 +53491,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lyh" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
-/area/clerk)
 "lzH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53877,13 +53893,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/entrance)
-"miD" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
-/area/clerk)
 "miX" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -55006,6 +55015,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ovk" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "ovM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55230,7 +55245,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/lounge)
-"oZD" = (
+"pau" = (
 /obj/item/instrument/eguitar,
 /obj/structure/rack,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -55281,12 +55296,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"pcF" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
-/area/clerk)
 "pdz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -55899,13 +55908,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qqY" = (
-/obj/machinery/door/airlock{
-	name = "Commissary";
-	req_access_txt = "36"
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "qrA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56636,6 +56638,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"rQe" = (
+/obj/machinery/door/airlock{
+	name = "Commissary";
+	req_access_txt = "36"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "rQW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -56878,15 +56887,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"sox" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
-/area/clerk)
 "soO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57499,6 +57499,17 @@
 "tiX" = (
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"tjF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "tkb" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics North West";
@@ -59550,6 +59561,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"wJE" = (
+/obj/effect/landmark/start/yogs/clerk,
+/turf/open/floor/plasteel{
+	icon_state = "wood"
+	},
+/area/clerk)
 "wKE" = (
 /obj/structure/chair{
 	dir = 8
@@ -60290,17 +60307,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"yeO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "yfa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83120,7 +83126,7 @@ arP
 arP
 kVU
 rPk
-yeO
+tjF
 xvj
 alu
 aHG
@@ -84404,7 +84410,7 @@ axo
 cCi
 aDz
 kVU
-qqY
+rQe
 kVU
 kVU
 kVU
@@ -84918,7 +84924,7 @@ axt
 ayG
 ayG
 ayG
-sox
+eJy
 ayG
 ayG
 ayG
@@ -85175,7 +85181,7 @@ axt
 ayG
 azK
 aBe
-kaU
+wJE
 aDj
 aER
 abN
@@ -85430,13 +85436,13 @@ aqR
 aqR
 axt
 ayG
-miD
-jmj
-lyh
+gCb
+jvL
+iMM
 aDi
 aEQ
 kaU
-pcF
+ovk
 kaU
 acF
 aLN
@@ -86203,7 +86209,7 @@ axt
 ayG
 azN
 xSu
-oZD
+pau
 aDy
 kaU
 aGf

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -17268,15 +17268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aLm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aLn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60165,6 +60156,12 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xWs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xWw" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -84931,7 +84928,7 @@ ayG
 ayG
 ayG
 ayG
-aLm
+aLl
 aLE
 aLE
 aPM
@@ -85188,7 +85185,7 @@ abN
 acm
 aJa
 ayG
-aLN
+xWs
 aLE
 aLE
 aLE


### PR DESCRIPTION
The current clerk office is BORING, it sells shoes and random shit that nobody wants. I turned it into a proper shop to sell things out of. By default is is a musical instrument shop, making it the best place on station to get the instruments we got with the rebase but never included in a map. But it is an adaptable layout and the clerk could sell whatever he wants out of it.

The Clerk also has a door that leads into the Abandoned Commissary, making it a more obvious project to fix it up and use it as extra shopping space.

~~Also fuck the haters that don't like the shutters. It looks cool and the original one had shutters too, so why can't this one.~~ Shutters are kill

![image](https://user-images.githubusercontent.com/20388263/48648201-820fd800-e9bc-11e8-9ade-168646f6684f.png)
[EDIT: the erroneous floor decal has been corrected]
[edit2: the shutters no longer exist, the doors to maint are now maint doors, and wrapping paper now exists] 

:cl:  
tweak: The clerk office on yogsbox now has a theme, and the clerk now has a direct door to the abandoned commissary if he/she wants to fix it up.
/:cl:
