### PR TITLE
Fixes syndie pinpointer typo

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/pinpointer.dm
+++ b/code/modules/antagonists/nukeop/equipment/pinpointer.dm
@@ -28,7 +28,7 @@
 					playsound(src, 'sound/items/nuke_toy_lowpower.ogg', 50, 0)
 					if(isliving(loc))
 						var/mob/living/L = loc
-						to_chat(L, "<span class='userdanger'>Your [name] vibrates and lets out a tinny alarm. Uh oh.</span>")
+						to_chat(L, "<span class='userdanger'>Your [name] vibrates and lets out a tiny alarm. Uh oh.</span>")
 
 /obj/item/pinpointer/nuke/scan_for_target()
 	target = null


### PR DESCRIPTION
When you arm the nuke the syndie pinpointer says a message and instead of "tiny alarm" it says "'tinny alarm" so I fixed it

🆑 
spellcheck: changes "tinny" to "tiny" in the syndie pinpointer alarm message
/:cl: