### PR TITLE
Turn your key Sir!

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -22393,10 +22393,6 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 29;
-	pixel_y = 8
-	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSz" = (
@@ -51353,6 +51349,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/library)
+"dvZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 0
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "dCA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -87762,7 +87767,7 @@ aRl
 aSx
 aTX
 aYg
-aWU
+dvZ
 cva
 adK
 aet
@@ -89304,7 +89309,7 @@ aRr
 aSD
 ceh
 aZj
-aWU
+dvZ
 cva
 adK
 aet

--- a/yogstation/code/modules/donor/borg_ai_skin_datums.dm
+++ b/yogstation/code/modules/donor/borg_ai_skin_datums.dm
@@ -103,6 +103,12 @@
 	owner = "fluffe9911"
 	module_locked = "Peacekeeper"
 
+/datum/borg_skin/mrsparako
+	name = "Mr. Sparako"
+	icon_state = "mrsparako"
+	owner = "nickvr628"
+
+
 //Begin AI skins://
 /* These follow the same format as borg skins*/
 

--- a/yogstation/code/modules/donor/borg_ai_skin_datums.dm
+++ b/yogstation/code/modules/donor/borg_ai_skin_datums.dm
@@ -103,12 +103,6 @@
 	owner = "fluffe9911"
 	module_locked = "Peacekeeper"
 
-/datum/borg_skin/mrsparako
-	name = "Mr. Sparako"
-	icon_state = "mrsparako"
-	owner = "nickvr628"
-
-
 //Begin AI skins://
 /* These follow the same format as borg skins*/
 


### PR DESCRIPTION
Don't you hate having to run all the way back to your office to swipe for red alert? Maybe the bridge is the only safe place left? No time to run to another authenticator? Fear not, because now there are TWO keycard authenticators on the bridge, spaced apart so you can see the other person but cannot run from one to the other. If you are crafty, you might be able to find a way to solo-activate red alert, but your best bet is to just have two people there.

![image](https://user-images.githubusercontent.com/20388263/53915163-714ba680-402d-11e9-820a-58fdf78e17d6.png)

Also you get to shout at people to TURN YOUR KEY and hold them at gunpoint until they unlock the BSA when Centcom sends Emergency Wartime Orders.

:cl:  
add: There are now two authenticators on the bridge so two Heads (or a crafty single head) can activate red alert from the same location. 
/:cl:
